### PR TITLE
update / create defaults are read-only Mapping

### DIFF
--- a/django-stubs/db/models/manager.pyi
+++ b/django-stubs/db/models/manager.pyi
@@ -1,5 +1,5 @@
 import datetime
-from collections.abc import AsyncIterator, Callable, Collection, Iterable, Iterator, MutableMapping, Sequence
+from collections.abc import AsyncIterator, Callable, Collection, Iterable, Iterator, Mapping, Sequence
 from typing import Any, Generic, NoReturn, TypeVar, overload
 
 from django.db.models.base import Model
@@ -63,20 +63,18 @@ class BaseManager(Generic[_T]):
     ) -> list[_T]: ...
     def bulk_update(self, objs: Iterable[_T], fields: Sequence[str], batch_size: int | None = ...) -> int: ...
     async def abulk_update(self, objs: Iterable[_T], fields: Sequence[str], batch_size: int | None = ...) -> int: ...
-    def get_or_create(self, defaults: MutableMapping[str, Any] | None = ..., **kwargs: Any) -> tuple[_T, bool]: ...
-    async def aget_or_create(
-        self, defaults: MutableMapping[str, Any] | None = ..., **kwargs: Any
-    ) -> tuple[_T, bool]: ...
+    def get_or_create(self, defaults: Mapping[str, Any] | None = ..., **kwargs: Any) -> tuple[_T, bool]: ...
+    async def aget_or_create(self, defaults: Mapping[str, Any] | None = ..., **kwargs: Any) -> tuple[_T, bool]: ...
     def update_or_create(
         self,
-        defaults: MutableMapping[str, Any] | None = ...,
-        create_defaults: MutableMapping[str, Any] | None = ...,
+        defaults: Mapping[str, Any] | None = ...,
+        create_defaults: Mapping[str, Any] | None = ...,
         **kwargs: Any,
     ) -> tuple[_T, bool]: ...
     async def aupdate_or_create(
         self,
-        defaults: MutableMapping[str, Any] | None = ...,
-        create_defaults: MutableMapping[str, Any] | None = ...,
+        defaults: Mapping[str, Any] | None = ...,
+        create_defaults: Mapping[str, Any] | None = ...,
         **kwargs: Any,
     ) -> tuple[_T, bool]: ...
     def earliest(self, *fields: str | OrderBy) -> _T: ...

--- a/django-stubs/db/models/query.pyi
+++ b/django-stubs/db/models/query.pyi
@@ -1,5 +1,5 @@
 import datetime
-from collections.abc import AsyncIterator, Collection, Iterable, Iterator, MutableMapping, Sequence, Sized
+from collections.abc import AsyncIterator, Collection, Iterable, Iterator, Mapping, Sequence, Sized
 from typing import Any, Generic, NamedTuple, overload
 
 from django.db.backends.utils import _ExecuteQuery
@@ -97,20 +97,18 @@ class QuerySet(Generic[_Model, _Row], Iterable[_Row], Sized):
     async def abulk_update(
         self, objs: Iterable[_Model], fields: Iterable[str], batch_size: int | None = ...
     ) -> int: ...
-    def get_or_create(self, defaults: MutableMapping[str, Any] | None = ..., **kwargs: Any) -> tuple[_Model, bool]: ...
-    async def aget_or_create(
-        self, defaults: MutableMapping[str, Any] | None = ..., **kwargs: Any
-    ) -> tuple[_Model, bool]: ...
+    def get_or_create(self, defaults: Mapping[str, Any] | None = ..., **kwargs: Any) -> tuple[_Model, bool]: ...
+    async def aget_or_create(self, defaults: Mapping[str, Any] | None = ..., **kwargs: Any) -> tuple[_Model, bool]: ...
     def update_or_create(
         self,
-        defaults: MutableMapping[str, Any] | None = ...,
-        create_defaults: MutableMapping[str, Any] | None = ...,
+        defaults: Mapping[str, Any] | None = ...,
+        create_defaults: Mapping[str, Any] | None = ...,
         **kwargs: Any,
     ) -> tuple[_Model, bool]: ...
     async def aupdate_or_create(
         self,
-        defaults: MutableMapping[str, Any] | None = ...,
-        create_defaults: MutableMapping[str, Any] | None = ...,
+        defaults: Mapping[str, Any] | None = ...,
+        create_defaults: Mapping[str, Any] | None = ...,
         **kwargs: Any,
     ) -> tuple[_Model, bool]: ...
     def earliest(self, *fields: str | OrderBy) -> _Row: ...


### PR DESCRIPTION
this allows a calling method to use a more specific TypedDict for instance

the underlying code does not mutate these, MutableMapping seems to be a leftover from when this was Dict[str, Any]

upstreamed as https://github.com/typeddjango/django-stubs/pull/2216